### PR TITLE
Use default visibility for exception_detail::clone_impl<T>

### DIFF
--- a/include/boost/exception/exception.hpp
+++ b/include/boost/exception/exception.hpp
@@ -432,6 +432,11 @@ boost
             {
             }
 
+#if defined(__GNUC__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
+#  pragma GCC visibility push (default)
+# endif
+#endif
         template <class T>
         class
         clone_impl:
@@ -473,6 +478,11 @@ boost
                 }
             };
         }
+#if defined(__GNUC__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
+#  pragma GCC visibility pop
+# endif
+#endif
 
     template <class T>
     inline


### PR DESCRIPTION
When building code with hidden visibility on ELF, exception classes must explicitly use the default visibility for catching to work across shared objects; the same must be done for all their base classes. While other classes in the `boost::exception_detail` namespace had visibility adjusted accordingly, `clone_impl<T>` didn't.

The newest version of clang started giving me a warning about this (possibly/probably due to some other changes that added catching):

>  ld: warning: direct access in `void boost::throw_exception<std::runtime_error>(std::runtime_error const&)` to global weak symbol `typeinfo for boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<std::runtime_error> >` means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.

Took me much head-scratching and digging around to realize that the `clone_impl` bit is relevant (`error_info_injector` already has correct visibility) — I do have consistent visibility settings across the projects involved. This PR fixes the warning and is exactly the same thing that is done for other classes in `exception.hpp`.

As a refresher in case you forgot all about it by now, here are some of the more relevant links I went through today:

1. Visibility author explaining the need for default visibility for exceptions *and* related classes:  http://stackoverflow.com/questions/14268736/symbol-visibility-exceptions-runtime-error
2. Previous Boost issue: https://svn.boost.org/trac/boost/ticket/4594
3. And a more recent related one: https://svn.boost.org/trac/boost/ticket/10899

