### PR TITLE
Remove references to std::exception when BOOST_NO_EXCEPTIONS is defined

### DIFF
--- a/include/boost/throw_exception.hpp
+++ b/include/boost/throw_exception.hpp
@@ -28,7 +28,9 @@
 
 #include <boost/detail/workaround.hpp>
 #include <boost/config.hpp>
+#ifndef BOOST_NO_EXCEPTIONS
 #include <exception>
+#endif
 
 #if !defined( BOOST_EXCEPTION_DISABLE ) && defined( __BORLANDC__ ) && BOOST_WORKAROUND( __BORLANDC__, BOOST_TESTED_AT(0x593) )
 # define BOOST_EXCEPTION_DISABLE
@@ -53,7 +55,8 @@ namespace boost
 {
 #ifdef BOOST_NO_EXCEPTIONS
 
-void throw_exception( std::exception const & e ); // user defined
+template <typename T>
+void throw_exception( T const & e ); // user defined
 
 #else
 


### PR DESCRIPTION
Removed #include directive for <exception> and std::exception from
boost::throw_exception user-defined function declaration.

This is necessary in platforms which do not have std::exception when
exceptions are disabled, such as AVR 8-bit CPUs (arduinos).