### PR TITLE
[CMake] Generate cmake target that other libraries can use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright 2018 Mike Dev
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+cmake_minimum_required(VERSION 3.5)
+project(BoostThrowException LANGUAGES CXX)
+
+add_library(boost_throw_exception INTERFACE)
+add_library(Boost::throw_exception ALIAS boost_throw_exception)
+
+target_include_directories(boost_throw_exception INTERFACE include)
+
+target_link_libraries(boost_static_assert
+    INTERFACE
+        Boost::assert
+        Boost::config
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(Boost::throw_exception ALIAS boost_throw_exception)
 
 target_include_directories(boost_throw_exception INTERFACE include)
 
-target_link_libraries(boost_static_assert
+target_link_libraries(boost_throw_exception
     INTERFACE
         Boost::assert
         Boost::config


### PR DESCRIPTION
... to express their dependency on this library and retrieve any
configuration information such as the include directory, binary
to link to (if any), transitive dependencies, necessary compiler
options or the required c++ standards level.