### PR TITLE
Removed extra semicolon

### DIFF
--- a/include/boost/exception/exception.hpp
+++ b/include/boost/exception/exception.hpp
@@ -12,7 +12,7 @@
 #include  <memory>
 namespace boost { namespace exception_detail { using std::shared_ptr; } }
 #else
-namespace boost { template <class T> class shared_ptr; };
+namespace boost { template <class T> class shared_ptr; }
 namespace boost { namespace exception_detail { using boost::shared_ptr; } }
 #endif
 


### PR DESCRIPTION
```
In file included from ../../../../boost/throw_exception.hpp:36:
../../../../boost/exception/exception.hpp:15:57: error: extra ';' outside of a function is a C++11 extension [-Werror,-Wc++11-extra-semi]
namespace boost { template <class T> class shared_ptr; };
                                                        ^
1 error generated.
```