### PR TITLE
Define boost::wrapexcept even when BOOST_EXCEPTION_DISABLE is defined.

### DIFF
--- a/include/boost/throw_exception.hpp
+++ b/include/boost/throw_exception.hpp
@@ -49,26 +49,7 @@ BOOST_NORETURN void throw_exception( std::exception const & e, boost::source_loc
 
 } // namespace boost
 
-#elif defined( BOOST_EXCEPTION_DISABLE )
-
-namespace boost
-{
-
-template<class E> BOOST_NORETURN void throw_exception( E const & e )
-{
-    throw_exception_assert_compatibility( e );
-    throw e;
-}
-
-template<class E> BOOST_NORETURN void throw_exception( E const & e, boost::source_location const & )
-{
-    throw_exception_assert_compatibility( e );
-    throw e;
-}
-
-} // namespace boost
-
-#else // !defined( BOOST_NO_EXCEPTIONS ) && !defined( BOOST_EXCEPTION_DISABLE )
+#else // !defined( BOOST_NO_EXCEPTIONS )
 
 #include <boost/exception/exception.hpp>
 
@@ -157,6 +138,31 @@ public:
     }
 };
 
+} // namespace boost
+
+#if defined( BOOST_EXCEPTION_DISABLE )
+
+namespace boost
+{
+
+template<class E> BOOST_NORETURN void throw_exception( E const & e )
+{
+    throw_exception_assert_compatibility( e );
+    throw e;
+}
+
+template<class E> BOOST_NORETURN void throw_exception( E const & e, boost::source_location const & )
+{
+    throw_exception_assert_compatibility( e );
+    throw e;
+}
+
+} // namespace boost
+
+#else // !defined( BOOST_EXCEPTION_DISABLE )
+
+namespace boost
+{
 // boost::throw_exception
 
 template<class E> BOOST_NORETURN void throw_exception( E const & e )
@@ -173,7 +179,9 @@ template<class E> BOOST_NORETURN void throw_exception( E const & e, boost::sourc
 
 } // namespace boost
 
-#endif
+#endif // # if defined( BOOST_EXCEPTION_DISABLE )
+
+#endif // # if defined( BOOST_NO_EXCEPTIONS )
 
 // BOOST_THROW_EXCEPTION
 


### PR DESCRIPTION
Since Boost.Exception started using `boost::wrapexcept` in implementation of `boost::exception_ptr`, we need to define it even when `BOOST_EXCEPTION_DISABLE` is defined, otherwise it won't compile:

```
$ clang++ -DBOOST_EXCEPTION_DISABLE -w -x c++ /usr/include/boost/exception_ptr.hpp -fsyntax-only
In file included from /usr/include/boost/exception_ptr.hpp:9:
/usr/include/boost/exception/detail/exception_ptr.hpp:87:49: error: use of undeclared identifier 'wrapexcept'
        return exception_ptr(boost::make_shared<wrapexcept<E> >(cp));
                                                ^
1 error generated.
```