### PR TITLE
Change del.p_=0 to del.p_=nullptr

### DIFF
--- a/include/boost/throw_exception.hpp
+++ b/include/boost/throw_exception.hpp
@@ -117,7 +117,6 @@ public:
         boost::exception_detail::copy_boost_exception( p, this );
 
         del.p_ = BOOST_NULLPTR;
-
         return p;
     }
 

--- a/include/boost/throw_exception.hpp
+++ b/include/boost/throw_exception.hpp
@@ -116,11 +116,7 @@ public:
 
         boost::exception_detail::copy_boost_exception( p, this );
 
-#if defined( BOOST_NO_CXX11_NULLPTR )
-        del.p_ = 0;
-#else
-        del.p_ = nullptr;
-#endif
+        del.p_ = BOOST_NULLPTR;
 
         return p;
     }

--- a/include/boost/throw_exception.hpp
+++ b/include/boost/throw_exception.hpp
@@ -116,7 +116,12 @@ public:
 
         boost::exception_detail::copy_boost_exception( p, this );
 
+#if defined( BOOST_NO_CXX11_NULLPTR )
+        del.p_ = 0;
+#else
         del.p_ = nullptr;
+#endif
+
         return p;
     }
 

--- a/include/boost/throw_exception.hpp
+++ b/include/boost/throw_exception.hpp
@@ -116,7 +116,7 @@ public:
 
         boost::exception_detail::copy_boost_exception( p, this );
 
-        del.p_ = 0;
+        del.p_ = nullptr;
         return p;
     }
 


### PR DESCRIPTION
A simple change (I hope) that cleans up compiler warnings and errors.